### PR TITLE
feat: add POST and DELETE endpoints for objects

### DIFF
--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -46,10 +46,147 @@ paths:
             $ref: '#/definitions/Error'
       parameters:
         - in: body
-          name: DrsObject
+          name: DrsPostObject
           description: The DrsObject info
           schema:
             $ref: '#/definitions/DrsObject'
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
+
+definitions:
+  DrsPostObject:
+    type: object
+    required: ['size', 'created_time', 'checksums']
+    properties:
+      name:
+        type: string
+        description: |-
+          A string that can be used to name a `DrsObject`.
+          This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+      size:
+        type: integer
+        format: int64
+        description: |-
+          For blobs, the blob size in bytes.
+          For bundles, the cumulative size, in bytes, of items in the `contents` field.
+      created_time:
+        type: string
+        format: date-time
+        description: |-
+          Timestamp of content creation in RFC3339.
+          (This is the creation time of the underlying content, not of the JSON object.)
+      updated_time:
+        type: string
+        format: date-time
+        description: >-
+          Timestamp of content update in RFC3339, identical to `created_time` in systems
+          that do not support updates.
+          (This is the update time of the underlying content, not of the JSON object.)
+      version:
+        type: string
+        description: >-
+          A string representing a version.
+
+          (Some systems may use checksum, a RFC3339 timestamp, or an incrementing version number.)
+      mime_type:
+        type: string
+        description: |-
+          A string providing the mime-type of the `DrsObject`.
+        example:
+          application/json
+      checksums:
+        type: array
+        minItems: 1
+        items:
+          $ref: '#/definitions/Checksum'
+        description: >-
+          The checksum of the `DrsObject`. At least one checksum must be provided.
+
+          For blobs, the checksum is computed over the bytes in the blob.
+
+
+          For bundles, the checksum is computed over a sorted concatenation of the
+          checksums of its top-level contained objects (not recursive, names not included).
+          The list of checksums is sorted alphabetically (hex-code) before concatenation
+          and a further checksum is performed on the concatenated checksum value.
+
+
+          For example, if a bundle contains blobs with the following checksums:
+
+          md5(blob1) = 72794b6d
+
+          md5(blob2) = 5e089d29
+
+
+          Then the checksum of the bundle is:
+
+          md5( concat( sort( md5(blob1), md5(blob2) ) ) )
+
+          = md5( concat( sort( 72794b6d, 5e089d29 ) ) )
+
+          = md5( concat( 5e089d29, 72794b6d ) )
+
+          = md5( 5e089d2972794b6d )
+
+          = f7a29a04
+      access_methods:
+        type: array
+        minItems: 1
+        items:
+          $ref: '#/definitions/AccessPostMethod'
+        description: |-
+          The list of access methods that can be used to fetch the `DrsObject`.
+          Required for single blobs; optional for bundles.
+      contents:
+        type: array
+        description: >-
+          If not set, this `DrsObject` is a single blob.
+
+          If set, this `DrsObject` is a bundle containing the listed `ContentsObject` s (some of which may be further nested).
+        items:
+          $ref: '#/definitions/ContentsObject'
+      description:
+        type: string
+        description: |-
+          A human readable description of the `DrsObject`.
+      aliases:
+        type: array
+        items:
+          type: string
+        description: >-
+          A list of strings that can be used to find other metadata
+          about this `DrsObject` from external metadata sources. These
+          aliases can be used to represent secondary
+          accession numbers or external GUIDs.
+
+  AccessPostMethod:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+        - s3
+        - gs
+        - ftp
+        - gsiftp
+        - globus
+        - htsget
+        - https
+        - file
+        description: >-
+          Type of the access method.
+      access_url:
+        $ref: '#/definitions/AccessURL'
+        description: >-
+          An `AccessURL` that can be used to fetch the actual object bytes.
+          Note that at least one of `access_url` and `access_id` must be provided.
+      region:
+        type: string
+        description: >-
+          Name of the region in the cloud service provider that the object belongs to.
+        example:
+          us-east-1
+    

--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -53,6 +53,60 @@ paths:
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
+  '/objects/{object_id}':
+    delete:
+      summary: Deletes the existing 'DrsObject'.
+      description: >-
+        Deletes the existing DrsObject
+      operationId: DeleteObject
+      responses:
+        '200':
+          description: The `DrsObject` was successfully deleted.
+          schema:
+            type: string
+        '202':
+          description: >
+            The operation is delayed and will continue asynchronously.
+            The client should retry this same request after the delay specified by Retry-After header.
+          headers:
+            Retry-After:
+              description: >
+                Delay in seconds. The client should retry this same request after waiting for this duration.
+                To simplify client response processing, this must be an integral relative time in seconds.
+                This value SHOULD represent the minimum duration the client should wait before attempting
+                the operation again with a reasonable expectation of success. When it is not feasible
+                for the server to determine the actual expected delay, the server may return a
+                brief, fixed value instead.
+              type: integer
+              format: int64
+        '400':
+          description: The request is malformed.
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: The request is unauthorized.
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: The requester is not authorized to perform this action.
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: The requested `DrsObject` wasn't found
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: An unexpected error occurred.
+          schema:
+            $ref: '#/definitions/Error'
+      parameters:
+        - name: object_id
+          in: path
+          required: true
+          type: string
+      tags:
+        - DataRepositoryService
+      x-swagger-router-controller: ga4gh.drs.server
 
 definitions:
   DrsPostObject:

--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -1,29 +1,15 @@
 paths:
   '/objects':
     post:
-      summary: Get info about a `DrsObject`
-      description: "Posts object metadata, and a list of access methods that can be used to fetch object bytes."
+      summary: Create object.
+      description: |-
+        Register metadata of a data object.
       operationId: RegisterObjects
       responses:
         '200':
-          description: The `DrsObject` was found successfully.
+          description: The `DrsObject` was successfully created.
           schema:
             type: string
-        '202':
-          description: >
-            The operation is delayed and will continue asynchronously.
-            The client should retry this same request after the delay specified by Retry-After header.
-          headers:
-            Retry-After:
-              description: >
-                Delay in seconds. The client should retry this same request after waiting for this duration.
-                To simplify client response processing, this must be an integral relative time in seconds.
-                This value SHOULD represent the minimum duration the client should wait before attempting
-                the operation again with a reasonable expectation of success. When it is not feasible
-                for the server to determine the actual expected delay, the server may return a
-                brief, fixed value instead.
-              type: integer
-              format: int64
         '400':
           description: The request is malformed.
           schema:
@@ -34,10 +20,6 @@ paths:
             $ref: '#/definitions/Error'
         '403':
           description: The requester is not authorized to perform this action.
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: The requested `DrsObject` wasn't found
           schema:
             $ref: '#/definitions/Error'
         '500':
@@ -46,39 +28,24 @@ paths:
             $ref: '#/definitions/Error'
       parameters:
         - in: body
-          name: DrsPostObject
-          description: The DrsObject info
+          name: PostDrsObject
+          description: Data object metadata.
           schema:
-            $ref: '#/definitions/DrsObject'
+            $ref: '#/definitions/PostDrsObject'
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
   '/objects/{object_id}':
     delete:
-      summary: Deletes the existing 'DrsObject'.
+      summary: Delete object.
       description: >-
-        Deletes the existing DrsObject
+        Delete existing `DrsObject`.
       operationId: DeleteObject
       responses:
         '200':
           description: The `DrsObject` was successfully deleted.
           schema:
             type: string
-        '202':
-          description: >
-            The operation is delayed and will continue asynchronously.
-            The client should retry this same request after the delay specified by Retry-After header.
-          headers:
-            Retry-After:
-              description: >
-                Delay in seconds. The client should retry this same request after waiting for this duration.
-                To simplify client response processing, this must be an integral relative time in seconds.
-                This value SHOULD represent the minimum duration the client should wait before attempting
-                the operation again with a reasonable expectation of success. When it is not feasible
-                for the server to determine the actual expected delay, the server may return a
-                brief, fixed value instead.
-              type: integer
-              format: int64
         '400':
           description: The request is malformed.
           schema:
@@ -92,7 +59,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
         '404':
-          description: The requested `DrsObject` wasn't found
+          description: The requested `DrsObject` wasn't found.
           schema:
             $ref: '#/definitions/Error'
         '500':
@@ -107,9 +74,8 @@ paths:
       tags:
         - DataRepositoryService
       x-swagger-router-controller: ga4gh.drs.server
-
 definitions:
-  DrsPostObject:
+  PostDrsObject:
     type: object
     required: ['size', 'created_time', 'checksums']
     properties:
@@ -117,13 +83,16 @@ definitions:
         type: string
         description: |-
           A string that can be used to name a `DrsObject`.
-          This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+          This string is made up of uppercase and lowercase letters, decimal
+          digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See
+          http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
       size:
         type: integer
         format: int64
         description: |-
           For blobs, the blob size in bytes.
-          For bundles, the cumulative size, in bytes, of items in the `contents` field.
+          For bundles, the cumulative size, in bytes, of items in the
+          `contents` field.
       created_time:
         type: string
         format: date-time
@@ -213,8 +182,8 @@ definitions:
           about this `DrsObject` from external metadata sources. These
           aliases can be used to represent secondary
           accession numbers or external GUIDs.
-
   AccessPostMethod:
+    description: Method through which object bytes can be fetched.
     type: object
     required:
       - type
@@ -243,4 +212,3 @@ definitions:
           Name of the region in the cloud service provider that the object belongs to.
         example:
           us-east-1
-    

--- a/drs_filer/config.yaml
+++ b/drs_filer/config.yaml
@@ -13,7 +13,11 @@ db:
         drsStore:
             collections:
                 objects:
-                    indexes: null
+                    indexes:
+                        - keys:
+                              id: 1
+                          options: 
+                            'unique': True
 
 api:
     specs:

--- a/drs_filer/config.yaml
+++ b/drs_filer/config.yaml
@@ -1,3 +1,4 @@
+# FOCA configuration
 server:
     host: '0.0.0.0'
     port: 8080
@@ -50,13 +51,12 @@ log:
         level: 10
         handlers: [console]
 
-
 exceptions:
     required_members: [['msg'], ['status_code']]
     status_member: ['status_code']
     exceptions: drs_filer.errors.exceptions.exceptions
 
-
+# Custom app configuration
 endpoints:
     objects:
         id_charset: 'string.ascii_letters + string.digits + ".-_~"'
@@ -64,4 +64,3 @@ endpoints:
     access_methods:
         id_charset: 'string.ascii_letters + string.digits + ".-_~"'
         id_length: 6
-

--- a/drs_filer/config.yaml
+++ b/drs_filer/config.yaml
@@ -50,7 +50,18 @@ log:
         level: 10
         handlers: [console]
 
+
 exceptions:
     required_members: [['msg'], ['status_code']]
     status_member: ['status_code']
     exceptions: drs_filer.errors.exceptions.exceptions
+
+
+endpoints:
+    objects:
+        id_charset: string.ascii_letters + string.digits + ".-_~"
+        id_length: 6
+    access_methods:
+        id_charset: string.ascii_letters + string.digits + ".-_~"
+        id_length: 6
+

--- a/drs_filer/config.yaml
+++ b/drs_filer/config.yaml
@@ -59,9 +59,9 @@ exceptions:
 
 endpoints:
     objects:
-        id_charset: string.ascii_letters + string.digits + ".-_~"
+        id_charset: 'string.ascii_letters + string.digits + ".-_~"'
         id_length: 6
     access_methods:
-        id_charset: string.ascii_letters + string.digits + ".-_~"
+        id_charset: 'string.ascii_letters + string.digits + ".-_~"'
         id_length: 6
 

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -3,7 +3,7 @@
 import logging
 from random import choice
 import string
-from typing import Dict
+from typing import (Dict, List)
 
 from flask import (current_app, request)
 from pymongo.errors import DuplicateKeyError
@@ -27,9 +27,10 @@ def register_new_objects(request: request) -> str:
     data = request.json
 
     # Add unique access identifiers for each access method
-    data['access_methods'] = __add_access_ids(
-        data=data['access_methods']
-    )
+    if 'access_methods' in data:
+        data['access_methods'] = __add_access_ids(
+            data=data['access_methods']
+        )
 
     while True:
         # Add object identifier and DRS URL
@@ -53,7 +54,7 @@ def register_new_objects(request: request) -> str:
     return data['id']
 
 
-def __add_access_ids(data: Dict) -> Dict:
+def __add_access_ids(data: List) -> List:
     """Add access identifiers to posted access methods metadata.
 
     Args:

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -1,6 +1,19 @@
 """Controller for adding new DRS objects."""
 
+from drs_filer.app import logger
+import string
+from typing import Dict
 from flask import (current_app, request)
+from random import choice
+from pymongo.errors import DuplicateKeyError
+
+MAIN_FIELDS_TO_OMIT = ["id", "self_uri"]
+
+ACCESS_FIELDS_TO_OMIT = ["access_id"]
+
+CHARSET = string.ascii_letters + string.digits + ".-_~"
+
+LENGTH = 6
 
 
 def register_new_objects(request: request) -> str:
@@ -16,5 +29,76 @@ def register_new_objects(request: request) -> str:
         current_app.config['FOCA'].db.dbs['drsStore'].
         collections['objects'].client
     )
-    db_collection.insert_one(request.json)
-    return request.json['id']
+
+    data = request.json
+    data = _prepare_access_data(data)
+
+    while True:
+        # Fill in the main fields
+        try:
+            generated_object_id = _create_id()
+            data['id'] = generated_object_id
+            data['self_uri'] = \
+                f"drs://{current_app.config['FOCA'].server.host}/{data['id']}"
+            db_collection.insert_one(data)
+        except DuplicateKeyError:
+            continue
+        except Exception as e:
+            raise e
+        logger.info(f"object with id: {data['id']} created.")
+        break
+
+    return data['id']
+
+
+def _prepare_access_data(data: Dict) -> Dict:
+    """Prepare acess data before registering into database
+
+    Args:
+        data: The data to be registered.
+
+    Returns:
+        The modified data suitable for registering.
+    """
+
+    # Delete the main fields first
+    for field in MAIN_FIELDS_TO_OMIT:
+        try:
+            del data[field]
+        except KeyError:
+            pass
+
+    try:
+        access_data = data["access_methods"]
+
+        # Delete access_fields
+        for field in ACCESS_FIELDS_TO_OMIT:
+            for method in access_data:
+                try:
+                    del method[field]
+                except KeyError:
+                    pass
+    except KeyError:
+        pass
+
+    # Fill in the access_ids first
+
+    try:
+        access_data = data["access_methods"]
+
+        access_id_set = set()
+        for field in ACCESS_FIELDS_TO_OMIT:
+            for method in access_data:
+                generated_access_id = _create_id()
+                if generated_access_id not in access_id_set:
+                    method[field] = generated_access_id
+                    access_id_set.add(generated_access_id)
+    except KeyError:
+        pass
+
+    return data
+
+
+def _create_id() -> str:
+    """Creates random ID."""
+    return ''.join(choice(CHARSET) for __ in range(LENGTH))

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -1,13 +1,14 @@
 """Controller for registering new DRS objects."""
 
+import logging
 from random import choice
-import string  # noqa: F401
+import string
 from typing import Dict
 
 from flask import (current_app, request)
 from pymongo.errors import DuplicateKeyError
 
-from drs_filer.app import logger
+logger = logging.getLogger(__name__)
 
 
 def register_new_objects(request: request) -> str:
@@ -23,9 +24,12 @@ def register_new_objects(request: request) -> str:
         current_app.config['FOCA'].db.dbs['drsStore'].
         collections['objects'].client
     )
+    data = request.json
 
     # Add unique access identifiers for each access method
-    data = __add_access_ids(data=request.json["access_methods"])
+    data['access_methods'] = __add_access_ids(
+        data=data['access_methods']
+    )
 
     while True:
         # Add object identifier and DRS URL

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -1,7 +1,7 @@
 """Controller for adding new DRS objects."""
 
 from drs_filer.app import logger
-import string
+import string  # noqa: F401
 from typing import Dict
 from flask import (current_app, request)
 from random import choice
@@ -28,8 +28,8 @@ def register_new_objects(request: request) -> str:
     while True:
         # Fill in the main fields
         try:
-            id_charset = current_app.config['FOCA'].\
-                endpoints['objects']['id_charset']
+            id_charset = eval(current_app.config['FOCA'].
+                              endpoints['objects']['id_charset'])
             id_length = current_app.config['FOCA'].\
                 endpoints['objects']['id_length']
             generated_object_id = __create_id(id_charset, id_length)
@@ -60,8 +60,8 @@ def prepare_access_data(data: Dict) -> Dict:
     # Generate the access_ids
     try:
         access_data = data["access_methods"]
-        id_charset = current_app.config['FOCA'].\
-            endpoints['access_methods']['id_charset']
+        id_charset = eval(current_app.config['FOCA'].
+                          endpoints['access_methods']['id_charset'])
         id_length = current_app.config['FOCA'].\
             endpoints['access_methods']['id_length']
         access_id_set = set()

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -3,7 +3,7 @@
 import logging
 from random import choice
 import string
-from typing import (Dict, List)
+from typing import (List)
 
 from flask import (current_app, request)
 from pymongo.errors import DuplicateKeyError

--- a/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
+++ b/drs_filer/ga4gh/drs/endpoints/register_new_objects.py
@@ -23,7 +23,7 @@ def register_new_objects(request: request) -> str:
     )
 
     data = request.json
-    data = _prepare_access_data(data)
+    data = prepare_access_data(data)
 
     while True:
         # Fill in the main fields
@@ -32,7 +32,7 @@ def register_new_objects(request: request) -> str:
                 endpoints['objects']['id_charset']
             id_length = current_app.config['FOCA'].\
                 endpoints['objects']['id_length']
-            generated_object_id = _create_id(id_charset, id_length)
+            generated_object_id = __create_id(id_charset, id_length)
             data['id'] = generated_object_id
             data['self_uri'] = \
                 f"drs://{current_app.config['FOCA'].server.host}/{data['id']}"
@@ -47,7 +47,7 @@ def register_new_objects(request: request) -> str:
     return data['id']
 
 
-def _prepare_access_data(data: Dict) -> Dict:
+def prepare_access_data(data: Dict) -> Dict:
     """Prepare acess data before registering into database
 
     Args:
@@ -66,7 +66,7 @@ def _prepare_access_data(data: Dict) -> Dict:
             endpoints['access_methods']['id_length']
         access_id_set = set()
         for method in access_data:
-            generated_access_id = _create_id(id_charset, id_length)
+            generated_access_id = __create_id(id_charset, id_length)
             if generated_access_id not in access_id_set:
                 method['access_id'] = generated_access_id
                 access_id_set.add(generated_access_id)
@@ -76,6 +76,6 @@ def _prepare_access_data(data: Dict) -> Dict:
     return data
 
 
-def _create_id(charset, length) -> str:
+def __create_id(charset, length) -> str:
     """Creates random ID."""
     return ''.join(choice(charset) for __ in range(length))

--- a/drs_filer/ga4gh/drs/server.py
+++ b/drs_filer/ga4gh/drs/server.py
@@ -77,13 +77,13 @@ def GetAccessURL(object_id: str, access_id: str) -> Dict:
 
 @log_traffic
 def DeleteObject(object_id):
-    """Deletes the DRS object.
+    """Delete DRS object.
 
     Args:
         object_id: Identifier of DRS object to be deleted.
 
     Returns:
-        The id of the object which was deleted.
+        `object_id` of deleted object.
     """
 
     db_collection = (

--- a/drs_filer/ga4gh/drs/server.py
+++ b/drs_filer/ga4gh/drs/server.py
@@ -73,3 +73,26 @@ def GetAccessURL(object_id: str, access_id: str) -> Dict:
     # Access IDs should be unique
     else:
         raise InternalServerError
+
+
+@log_traffic
+def DeleteObject(object_id):
+    """Deletes the DRS object.
+
+    Args:
+        object_id: Identifier of DRS object to be deleted.
+
+    Returns:
+        The id of the object which was deleted.
+    """
+
+    db_collection = (
+        current_app.config['FOCA'].db.dbs['drsStore'].
+        collections['objects'].client
+    )
+    obj = db_collection.find_one({"id": object_id})
+    if not obj:
+        raise ObjectNotFound
+    else:
+        db_collection.remove({"id": object_id})
+        return object_id

--- a/drs_filer/ga4gh/drs/server.py
+++ b/drs_filer/ga4gh/drs/server.py
@@ -94,5 +94,5 @@ def DeleteObject(object_id):
     if not obj:
         raise ObjectNotFound
     else:
-        db_collection.remove({"id": object_id})
+        db_collection.delete_one({"id": object_id})
         return object_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-foca==0.4.0
+foca==0.5.0
 gunicorn==20.0.4
 setuptools==46.4.0

--- a/tests/ga4gh/drs/endpoints/test_register_new_object.py
+++ b/tests/ga4gh/drs/endpoints/test_register_new_object.py
@@ -101,11 +101,6 @@ def test_add_access_ids():
     """Test for __add_access_ids()."""
     app = Flask(__name__)
     app.config['FOCA'] = Config(endpoints=ENDPOINT_CONFIG)
-
-def test_add_access_ids():
-    """Test for __add_access_ids()."""
-    app = Flask(__name__)
-    app.config['FOCA'] = Config(endpoints=ENDPOINT_CONFIG)
     objects = json.loads(open(data_objects_path, "r").read())
     mock_data = objects[0]['access_methods']
     with app.app_context():

--- a/tests/ga4gh/drs/endpoints/test_register_new_object.py
+++ b/tests/ga4gh/drs/endpoints/test_register_new_object.py
@@ -1,16 +1,123 @@
 from drs_filer.ga4gh.drs.endpoints.register_new_objects import (
-    register_new_objects)
+    register_new_objects, prepare_access_data)
 import mongomock
 import pytest
+from pymongo.errors import DuplicateKeyError
+
+from flask import Flask
+from foca.models.config import Config, MongoConfig
 
 from addict import Dict
+import json
 
 
-def test_register_new_object():
-    """registerNewObject should raise an exception on duplicate key"""
-    collection = mongomock.MongoClient().db.collection
-    json_data = Dict()
-    json_data.json = {"id": "1"}
-    collection.insert_one(json_data.json)
-    with pytest.raises(Exception):
-        register_new_objects(json_data)
+INDEX_CONFIG = {
+    'keys': [('id', 1)]
+}
+
+COLLECTION_CONFIG = {
+    'indexes': [INDEX_CONFIG],
+}
+
+DB_CONFIG = {
+    'collections': {
+        'objects': COLLECTION_CONFIG,
+    },
+}
+
+MONGO_CONFIG = {
+    'host': 'mongodb',
+    'port': 27017,
+    'dbs': {
+        'drsStore': DB_CONFIG,
+    },
+}
+
+ENDPOINT_CONFIG = {
+    "objects": {
+        "id_charset": "abcde",
+        "id_length": 6
+    },
+    "access_methods": {
+        "id_charset": "abcde",
+        "id_length": 6
+    }
+}
+
+INVALID_ENDPOINT_CONFIG = {
+    "object": {
+        "id_charset": "abcde",
+        "id_length": 6
+    },
+    "access_methods": {
+        "id_charset": "abcde",
+        "id_length": 6
+    }
+}
+
+ENDPOINT_CONFIG_DUPLICATE = {
+    "objects": {
+        "id_charset": "a",
+        "id_length": 1
+    },
+    "access_methods": {
+        "id_charset": "B",
+        "id_length": 1
+    }
+}
+
+data_objects_path = "tests/data_objects.json"
+
+
+def test_register_new_object_exception():
+    """registerNewObject should raise an exception on INVALID_ENDPOINT_CONFIG.
+    """
+
+    app = Flask(__name__)
+    app.config['FOCA'] = \
+        Config(
+            db=MongoConfig(**MONGO_CONFIG), endpoints=INVALID_ENDPOINT_CONFIG
+        )
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client = mongomock.MongoClient().db.collection
+    request_data = Dict()
+    request_data.json = {"name": "mock_name"}
+    with app.app_context():
+        with pytest.raises(KeyError):
+            register_new_objects(request_data)
+
+
+def test_register_new_object_duplicate_key_error():
+    """registerNewObject should raise an exception on INVALID_ENDPOINT_CONFIG.
+    """
+    app = Flask(__name__)
+    app.config['FOCA'] = \
+        Config(
+            db=MongoConfig(**MONGO_CONFIG),
+            endpoints=ENDPOINT_CONFIG_DUPLICATE
+        )
+    # app.config['FOCA'].db.dbs['drsStore']. \
+    #     collections['objects'].client = mongomock.MongoClient().db.collection
+    # app.config['FOCA'].db.dbs['drsStore']. \
+    #     collections['objects'].client = MagicMock()
+    # mock = MagicMock(side_effect=DuplicateKeyError(''))
+    # app.config['FOCA'].db.dbs['drsStore']. \
+    #     collections['objects'].client.insert_one = mock
+    # app.config['FOCA'].db.dbs['drsStore'].collections['objects'].client.insert_one = MagicMock(side_effect = DuplicateKeyError(''))
+    # print()
+    request_data = Dict()
+    request_data.json = {"name": "mock_name"}
+    with app.app_context():
+        with pytest.raises(DuplicateKeyError):
+            register_new_objects(request_data)
+
+
+def test_prepare_access_data():
+    """Test for prepare_access_data"""
+    app = Flask(__name__)
+    app.config['FOCA'] = Config(endpoints=ENDPOINT_CONFIG)
+    objects = json.loads(open(data_objects_path, "r").read())
+    mock_data = objects[0]
+    with app.app_context():
+        res = prepare_access_data(mock_data)
+        assert isinstance(res, dict)

--- a/tests/ga4gh/drs/endpoints/test_register_new_object.py
+++ b/tests/ga4gh/drs/endpoints/test_register_new_object.py
@@ -2,11 +2,13 @@ from drs_filer.ga4gh.drs.endpoints.register_new_objects import (
     register_new_objects, prepare_access_data)
 import mongomock
 import pytest
+import string  # noqa: F401
+
 from pymongo.errors import DuplicateKeyError
 
 from flask import Flask
 from foca.models.config import Config, MongoConfig
-
+from unittest.mock import MagicMock
 from addict import Dict
 import json
 
@@ -35,34 +37,23 @@ MONGO_CONFIG = {
 
 ENDPOINT_CONFIG = {
     "objects": {
-        "id_charset": "abcde",
+        "id_charset": 'string.digits',
         "id_length": 6
     },
     "access_methods": {
-        "id_charset": "abcde",
+        "id_charset": 'string.digits',
         "id_length": 6
     }
 }
 
 INVALID_ENDPOINT_CONFIG = {
     "object": {
-        "id_charset": "abcde",
+        "id_charset": 'string.digits',
         "id_length": 6
     },
     "access_methods": {
-        "id_charset": "abcde",
+        "id_charset": 'string.digits"',
         "id_length": 6
-    }
-}
-
-ENDPOINT_CONFIG_DUPLICATE = {
-    "objects": {
-        "id_charset": "a",
-        "id_length": 1
-    },
-    "access_methods": {
-        "id_charset": "B",
-        "id_length": 1
     }
 }
 
@@ -88,28 +79,25 @@ def test_register_new_object_exception():
 
 
 def test_register_new_object_duplicate_key_error():
-    """registerNewObject should raise an exception on INVALID_ENDPOINT_CONFIG.
+    """test registerNewObject for DuplicateKeyError.
     """
     app = Flask(__name__)
     app.config['FOCA'] = \
         Config(
             db=MongoConfig(**MONGO_CONFIG),
-            endpoints=ENDPOINT_CONFIG_DUPLICATE
+            endpoints=ENDPOINT_CONFIG
         )
-    # app.config['FOCA'].db.dbs['drsStore']. \
-    #     collections['objects'].client = mongomock.MongoClient().db.collection
-    # app.config['FOCA'].db.dbs['drsStore']. \
-    #     collections['objects'].client = MagicMock()
-    # mock = MagicMock(side_effect=DuplicateKeyError(''))
-    # app.config['FOCA'].db.dbs['drsStore']. \
-    #     collections['objects'].client.insert_one = mock
-    # app.config['FOCA'].db.dbs['drsStore'].collections['objects'].client.insert_one = MagicMock(side_effect = DuplicateKeyError(''))
-    # print()
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client = mongomock.MongoClient().db.collection
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client = MagicMock()
+    mock = MagicMock(side_effect=[DuplicateKeyError(''), None])
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client.insert_one = mock
     request_data = Dict()
     request_data.json = {"name": "mock_name"}
     with app.app_context():
-        with pytest.raises(DuplicateKeyError):
-            register_new_objects(request_data)
+        assert isinstance(register_new_objects(request_data), str)
 
 
 def test_prepare_access_data():

--- a/tests/ga4gh/drs/endpoints/test_register_new_object.py
+++ b/tests/ga4gh/drs/endpoints/test_register_new_object.py
@@ -1,5 +1,8 @@
 from drs_filer.ga4gh.drs.endpoints.register_new_objects import (
-    register_new_objects, prepare_access_data)
+    __add_access_ids,
+    register_new_objects,
+    generate_id,
+)
 import mongomock
 import pytest
 import string  # noqa: F401
@@ -16,17 +19,14 @@ import json
 INDEX_CONFIG = {
     'keys': [('id', 1)]
 }
-
 COLLECTION_CONFIG = {
     'indexes': [INDEX_CONFIG],
 }
-
 DB_CONFIG = {
     'collections': {
         'objects': COLLECTION_CONFIG,
     },
 }
-
 MONGO_CONFIG = {
     'host': 'mongodb',
     'port': 27017,
@@ -34,7 +34,6 @@ MONGO_CONFIG = {
         'drsStore': DB_CONFIG,
     },
 }
-
 ENDPOINT_CONFIG = {
     "objects": {
         "id_charset": 'string.digits',
@@ -45,7 +44,6 @@ ENDPOINT_CONFIG = {
         "id_length": 6
     }
 }
-
 INVALID_ENDPOINT_CONFIG = {
     "object": {
         "id_charset": 'string.digits',
@@ -79,8 +77,7 @@ def test_register_new_object_exception():
 
 
 def test_register_new_object_duplicate_key_error():
-    """test registerNewObject for DuplicateKeyError.
-    """
+    """Test registerNewObject for DuplicateKeyError."""
     app = Flask(__name__)
     app.config['FOCA'] = \
         Config(
@@ -95,17 +92,29 @@ def test_register_new_object_duplicate_key_error():
     app.config['FOCA'].db.dbs['drsStore']. \
         collections['objects'].client.insert_one = mock
     request_data = Dict()
-    request_data.json = {"name": "mock_name"}
+    request_data.json = {"name": "mock_name", "access_methods": []}
     with app.app_context():
         assert isinstance(register_new_objects(request_data), str)
 
 
-def test_prepare_access_data():
-    """Test for prepare_access_data"""
+def test_add_access_ids():
+    """Test for __add_access_ids()."""
+    app = Flask(__name__)
+    app.config['FOCA'] = Config(endpoints=ENDPOINT_CONFIG)
+
+def test_add_access_ids():
+    """Test for __add_access_ids()."""
     app = Flask(__name__)
     app.config['FOCA'] = Config(endpoints=ENDPOINT_CONFIG)
     objects = json.loads(open(data_objects_path, "r").read())
-    mock_data = objects[0]
+    mock_data = objects[0]['access_methods']
     with app.app_context():
-        res = prepare_access_data(mock_data)
-        assert isinstance(res, dict)
+        res = __add_access_ids(mock_data)
+        print(res)
+        assert isinstance(res, list)
+
+
+def test_generate_id():
+    """Test for 'generate_id()'."""
+    random_id = generate_id()
+    assert isinstance(random_id, str)

--- a/tests/ga4gh/drs/test_server.py
+++ b/tests/ga4gh/drs/test_server.py
@@ -16,11 +16,7 @@ from foca.models.config import Config
 from flask import Flask
 
 INDEX_CONFIG = {
-    'keys': [('last_name', -1)],
-    'name': 'indexLastName',
-    'unique': True,
-    'background': False,
-    'sparse': False,
+    'keys': [('last_name', -1)]
 }
 
 COLLECTION_CONFIG = {

--- a/tests/ga4gh/drs/test_server.py
+++ b/tests/ga4gh/drs/test_server.py
@@ -1,5 +1,3 @@
-from drs_filer.ga4gh.drs import endpoints
-from os import access
 from flask import json
 from foca.models.config import MongoConfig
 from drs_filer.errors.exceptions import (
@@ -45,11 +43,11 @@ MONGO_CONFIG = {
 
 ENDPOINT_CONFIG = {
     "objects": {
-        "id_charset": "abcde",
+        "id_charset": 'string.digits',
         "id_length": 6
     },
     "access_methods": {
-        "id_charset": "abcde",
+        "id_charset": "string.digits",
         "id_length": 6
     }
 }
@@ -186,7 +184,7 @@ def test_GetAccessURL_Key_Error():
 
 
 def test_GetAccessURL_Duplicate_Access_Id():
-    """GetAccessURL should return Internal Server Error on duplicate access keys
+    """GetAccessURL should return Internal Server Error on duplicate access keys.
     """
     app = Flask(__name__)
     app.config['FOCA'] = Config(db=MongoConfig(**MONGO_CONFIG))

--- a/tests/ga4gh/drs/test_server.py
+++ b/tests/ga4gh/drs/test_server.py
@@ -1,10 +1,16 @@
+from drs_filer.ga4gh.drs import endpoints
+from os import access
 from flask import json
 from foca.models.config import MongoConfig
 from drs_filer.errors.exceptions import (
     URLNotFound,
     ObjectNotFound,
     InternalServerError)
-from drs_filer.ga4gh.drs.server import GetObject, GetAccessURL, RegisterObjects
+from drs_filer.ga4gh.drs.server import (
+    DeleteObject,
+    GetObject,
+    GetAccessURL,
+    RegisterObjects)
 import mongomock
 import pytest
 
@@ -37,19 +43,30 @@ MONGO_CONFIG = {
     },
 }
 
+ENDPOINT_CONFIG = {
+    "objects": {
+        "id_charset": "abcde",
+        "id_length": 6
+    },
+    "access_methods": {
+        "id_charset": "abcde",
+        "id_length": 6
+    }
+}
+
 data_objects_path = "tests/data_objects.json"
 
 
 def test_RegisterObjects():
     """Test for registering new DRSObject"""
     app = Flask(__name__)
-    app.config['FOCA'] = Config(db=MongoConfig(**MONGO_CONFIG))
+    app.config['FOCA'] = \
+        Config(db=MongoConfig(**MONGO_CONFIG), endpoints=ENDPOINT_CONFIG)
     app.config['FOCA'].db.dbs['drsStore']. \
         collections['objects'].client = mongomock.MongoClient().db.collection
-
-    with app.test_request_context(json={"id": "1"}):
+    with app.test_request_context(json={"name": "drsObject"}):
         res = RegisterObjects.__wrapped__()
-        assert res == "1"
+        assert isinstance(res, str)
 
 
 def test_GetObject():
@@ -184,3 +201,37 @@ def test_GetAccessURL_Duplicate_Access_Id():
     with app.app_context():
         with pytest.raises(InternalServerError):
             GetAccessURL.__wrapped__("a003", "3")
+
+
+def test_DeleteObject():
+    """DeleteObject should return the id of the deleted object"""
+    app = Flask(__name__)
+    app.config['FOCA'] = \
+        Config(db=MongoConfig(**MONGO_CONFIG), endpoints=ENDPOINT_CONFIG)
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client = mongomock.MongoClient().db.collection
+    objects = json.loads(open(data_objects_path, "r").read())
+    for obj in objects:
+        obj['_id'] = app.config['FOCA'].db.dbs['drsStore']. \
+            collections['objects'].client.insert_one(obj).inserted_id
+    del objects[0]['_id']
+    with app.app_context():
+        res = DeleteObject.__wrapped__("a001")
+        assert res == "a001"
+
+
+def test_DeleteObject_Not_Found():
+    """ObjectNotFound should be raised if object id is not found"""
+    app = Flask(__name__)
+    app.config['FOCA'] = \
+        Config(db=MongoConfig(**MONGO_CONFIG), endpoints=ENDPOINT_CONFIG)
+    app.config['FOCA'].db.dbs['drsStore']. \
+        collections['objects'].client = mongomock.MongoClient().db.collection
+    objects = json.loads(open(data_objects_path, "r").read())
+    for obj in objects:
+        obj['_id'] = app.config['FOCA'].db.dbs['drsStore']. \
+            collections['objects'].client.insert_one(obj).inserted_id
+    del objects[0]['_id']
+    with app.app_context():
+        with pytest.raises(ObjectNotFound):
+            DeleteObject.__wrapped__("01")


### PR DESCRIPTION
## Description

* add specs for `POST /objects` and `DELETE /objects/{object_id}` endpoints
* implement endpoint logic
* properties `id`, `self_uri` and `access_id` in the `Object` definition of the [DRS specs](https://github.com/ga4gh/data-repository-service-schemas/blob/master/openapi/data_repository_service.swagger.yaml) are auto-populated upon `POST`ing objects

Fixes #8 and #10 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable