### PR TITLE
build: add Helm chart for OpenShift deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,5 @@ RUN cd /app \
   && python setup.py develop \
   && cd / \
   && chmod g+w /app/drs_filer/api/
+
+CMD ["bash", "-c", "cd /app/drs_filer; python app.py"]

--- a/deployment/.helmignore
+++ b/deployment/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: drs-filer
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,26 @@
+# DRS filer Helm chart
+
+## Quick start
+
+1. Edit `values.yaml`. It is important to change `host_name` to the URL you want the application to respond to.
+
+2. Install the Helm chart. Run this from the `deployment` folder:
+```
+helm install drs-filer . -n namespace
+```
+`namespace` is the name of the namespace where the cluster should be installed.
+`drs-filer` could be any name, it will be referenced later for upgrading or uninstalling.
+
+## Upgrades
+
+If you need to change any parameter of the deployment, the procedure is similar to installing:
+
+1. Edit `values.yaml` with the new configuration you want to apply. For example, if you want to change the image of drs-filer, change `drs_filer.image`.
+
+2. Upgrade the Helm chart. Run this from the `deployment` folder:
+```
+helm upgrade drs-filer . -n namespace
+```
+`namespace` is the name of the namespace where the cluster was installed.
+`drs-filer` is the name given when installing. In order to see the correct name, do a `helm ls -n namespace`.
+

--- a/deployment/templates/drs-filer-deploy.yaml
+++ b/deployment/templates/drs-filer-deploy.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: drs-filer
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: drs-filer
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: drs-filer
+    spec:
+      containers:
+      - image: {{ .Values.drs_filer.image }}
+        imagePullPolicy: Always
+        name: drs-filer
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:

--- a/deployment/templates/drs-filer-route.yaml
+++ b/deployment/templates/drs-filer-route.yaml
@@ -1,0 +1,20 @@
+{{ if eq .Values.clusterType "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: drs-filer
+spec:
+  host: {{ .Values.host_name }}
+  port:
+    targetPort: drs-filer
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: drs-filer
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []
+{{ end }}

--- a/deployment/templates/drs-filer-service.yaml
+++ b/deployment/templates/drs-filer-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: drs-filer
+spec:
+  ports:
+  - name: drs-filer
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: drs-filer
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/deployment/templates/mongo-deploy.yaml
+++ b/deployment/templates/mongo-deploy.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: mongodb
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: mongodb
+    spec:
+      containers:
+      - image: {{ .Values.mongodb.image }}
+        imagePullPolicy: Always
+        name: mongodb
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data/db/
+          name: mongodb
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: mongodb
+        persistentVolumeClaim:
+          claimName: mongodb
+status:

--- a/deployment/templates/mongo-pvc.yaml
+++ b/deployment/templates/mongo-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.mongodb.volumeSize }}
+status:

--- a/deployment/templates/mongo-service.yaml
+++ b/deployment/templates/mongo-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+spec:
+  ports:
+  - name: mongodb
+    port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: mongodb
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -1,0 +1,14 @@
+# Default values for drs-filer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+clusterType: openshift
+
+host_name: drs-filer-test.c03.k8s-popup.csc.fi
+
+drs_filer:
+  image: lvarin/drs-filer:latest
+
+mongodb:
+  image: mongo:3.6
+  volumeSize: 1Gi


### PR DESCRIPTION
## Description

- Add a Helm chart to deploy DRS-Filer; config files in directory `/deployment`
- Includes basic documentation
- Currently only works on OpenShift, as it has a Route not an Ingress

Fixes #15