### PR TITLE
fix: remove broken examples

### DIFF
--- a/drs_filer/api/20200622.383121d.data_repository_service.swagger.yaml
+++ b/drs_filer/api/20200622.383121d.data_repository_service.swagger.yaml
@@ -317,8 +317,8 @@ definitions:
         description: >-
           An optional list of headers to include in the HTTP request to `url`.
           These headers can be used to provide auth tokens required to fetch the object bytes.
-        example:
-          Authorization: Basic Z2E0Z2g6ZHJz
+        # example:
+        #   Authorization: Basic Z2E0Z2g6ZHJz
   AccessMethod:
     type: object
     required:

--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -229,8 +229,6 @@ definitions:
         description: >-
           An optional list of headers to include in the HTTP request to `url`.
           These headers can be used to provide auth tokens required to fetch the object bytes.
-        example:
-          Authorization: Basic Z2E0Z2g6ZHJz
   ChecksumRegister:
     type: object
     additionalProperties: false

--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -277,7 +277,8 @@ definitions:
           that may be used to obtain the object.
           These URIs may be external to this DRS instance.
         example:
-          drs://drs.example.org/314159
+          - drs://drs.example.org/314159
+          - drs://drs.example.org/213512
         items:
           type: string
       contents:
@@ -288,6 +289,7 @@ definitions:
           describe the objects within the nested bundle.
         items:
           $ref: '#/definitions/ContentsObjectRegister'
+        example: []
     required:
       - name
 tags:


### PR DESCRIPTION
## Description

Several examples in the original TES specs and the custom additions by TRS-Filer have been updated such that a valid example request payload for the `POST /objects` endpoint is rendered on the Swagger UI.