### PR TITLE
feat: clarify error

### DIFF
--- a/drs_filer/api/additional.data_repository_service.swagger.yaml
+++ b/drs_filer/api/additional.data_repository_service.swagger.yaml
@@ -175,6 +175,10 @@ paths:
             description: The requested resource was not found.
             schema:
               $ref: '#/definitions/Error'
+        '409':
+            description: Refusing to delete the last remaining access method.
+            schema:
+              $ref: '#/definitions/Error'
         '500':
             description: An unexpected error occurred.
             schema:

--- a/drs_filer/errors/exceptions.py
+++ b/drs_filer/errors/exceptions.py
@@ -6,10 +6,17 @@ from connexion.exceptions import (
 )
 
 from werkzeug.exceptions import (
+    Conflict,
     BadRequest,
     InternalServerError,
     NotFound,
 )
+
+
+class AccessMethodNotDeleted(Conflict):
+    """Raised when the client attempts to delete the last remaining access
+    method of an object."""
+    pass
 
 
 class AccessMethodNotFound(NotFound):
@@ -64,6 +71,10 @@ exceptions = {
     AccessMethodNotFound: {
         "msg": "The requested access method wasn't found.",
         "status_code": '404',
+    },
+    AccessMethodNotDeleted: {
+        "msg": "Refusing to delete the last remaining access method.",
+        "status_code": '409',
     },
     ObjectNotFound: {
         "msg": "The requested `DrsObject` wasn't found.",

--- a/drs_filer/ga4gh/drs/server.py
+++ b/drs_filer/ga4gh/drs/server.py
@@ -7,11 +7,11 @@ from flask import (current_app, request)
 from foca.utils.logging import log_traffic
 
 from drs_filer.errors.exceptions import (
+    AccessMethodNotDeleted,
     AccessMethodNotFound,
     InternalServerError,
     ObjectNotFound,
     URLNotFound,
-    BadRequest,
 )
 from drs_filer.ga4gh.drs.endpoints.register_objects import (
     register_object,
@@ -132,9 +132,11 @@ def DeleteAccessMethod(object_id: str, access_id: str) -> str:
         access_id: Identifier of the access method to be deleted
 
     Returns:
-        `access_id` of deleted object. Note that a
-        `BadRequest/400` error response is returned if attempting to delete
-        the only remaining access method.
+        `access_id` of deleted object.
+
+    Raises:
+        drs_filer.errors.exceptions.AccessMethodNotDeleted: If attempting to
+            delete the last remaining access method.
     """
 
     db_collection = (
@@ -153,7 +155,7 @@ def DeleteAccessMethod(object_id: str, access_id: str) -> str:
             "Will not delete only remaining access method for object: "
             f"{object_id}"
         )
-        raise BadRequest
+        raise AccessMethodNotDeleted
 
     del_access_methods = db_collection.update_one(
         filter={'id': object_id},

--- a/tests/ga4gh/drs/test_server.py
+++ b/tests/ga4gh/drs/test_server.py
@@ -324,7 +324,7 @@ def test_DeleteAccessMethod_AccessMethodNotFound():
             DeleteAccessMethod.__wrapped__("a011", MOCK_ID_NA)
 
 
-def test_DeleteAcessMethod_AccessMethodNotDeleted(monkeypatch):
+def test_DeleteAccessMethod_AccessMethodNotDeleted(monkeypatch):
     """Test for deleting an access method `access_id` of an object associated
     with a given `object_id` when that access method is the last remaining
     access method associated with object.

--- a/tests/ga4gh/drs/test_server.py
+++ b/tests/ga4gh/drs/test_server.py
@@ -10,8 +10,8 @@ from foca.models.config import Config
 from foca.models.config import MongoConfig
 
 from drs_filer.errors.exceptions import (
+    AccessMethodNotDeleted,
     AccessMethodNotFound,
-    BadRequest,
     URLNotFound,
     ObjectNotFound,
     InternalServerError)
@@ -324,7 +324,7 @@ def test_DeleteAccessMethod_AccessMethodNotFound():
             DeleteAccessMethod.__wrapped__("a011", MOCK_ID_NA)
 
 
-def test_DeleteAcessMethod_BadRequest(monkeypatch):
+def test_DeleteAcessMethod_AccessMethodNotDeleted(monkeypatch):
     """Test for deleting an access method `access_id` of an object associated
     with a given `object_id` when that access method is the last remaining
     access method associated with object.
@@ -341,7 +341,7 @@ def test_DeleteAcessMethod_BadRequest(monkeypatch):
         app.config.foca.db.dbs['drsStore']. \
             collections['objects'].client.insert_one(obj)
     with app.app_context():
-        with pytest.raises(BadRequest):
+        with pytest.raises(AccessMethodNotDeleted):
             DeleteAccessMethod.__wrapped__("a001", "1")
 
 


### PR DESCRIPTION
## Description

Change error response from `400` to `409` and return an informative error message if the client attempts to delete the last remaining access method of an object. The OpenAPI specfication was updated accordingly.

Fixes #53

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new exception `AccessMethodNotDeleted` to handle cases where the last remaining access method of an object is attempted to be deleted. The `DeleteAccessMethod` function and related tests have been updated accordingly. Additionally, the API documentation has been updated to reflect the new `409` error response.

- **New Features**:
    - Introduced a new exception `AccessMethodNotDeleted` to handle cases where the last remaining access method of an object is attempted to be deleted.
- **Enhancements**:
    - Updated the `DeleteAccessMethod` function to raise `AccessMethodNotDeleted` instead of `BadRequest` when attempting to delete the last remaining access method.
- **Documentation**:
    - Updated the API documentation to include the new `409` error response for refusing to delete the last remaining access method.
- **Tests**:
    - Renamed and updated the test case to check for `AccessMethodNotDeleted` exception instead of `BadRequest` when deleting the last remaining access method.

<!-- Generated by sourcery-ai[bot]: end summary -->