### PR TITLE
build: add missing arg in config map update script

### DIFF
--- a/update-config-map.sh
+++ b/update-config-map.sh
@@ -38,6 +38,7 @@ echo "Current Kubernetes namespace: $NAMESPACE"; echo
 echo " * Getting current default configuration"
 
 APP_CONFIG=$(yq --arg HOST_NAME "$HOST_NAME" \
+                --arg MONGO_HOST "$MONGO_HOST" \
     '.endpoints.url_prefix = "https" |
      .endpoints.external_host = $HOST_NAME |
      .endpoints.external_port = 443 |


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix missing --arg parameter in the update-config-map.sh script to correctly update the configuration map with the MONGO_HOST value.

Bug Fixes:
- Add missing --arg parameter for MONGO_HOST in update-config-map.sh script to ensure proper configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->