### PR TITLE
Fix PathType. Increase memory limits and requests for Mongo

### DIFF
--- a/deployment/templates/drs-filer-ingress.yaml
+++ b/deployment/templates/drs-filer-ingress.yaml
@@ -9,7 +9,7 @@ spec:
       http:
         paths:
           - path: /ga4gh/drs/v1
-            pathType: prefix
+            pathType: Prefix
             backend:
               service:
                 name: drs-filer

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -25,7 +25,7 @@ mongodb:
   resources:
     limits:
       cpu: 200m
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 200m
-      memory: 256Mi
+      memory: 512Mi


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not reduced the existing code coverage
- [ ] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [ ] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

## Summary by Sourcery

Adjust MongoDB resource configuration and correct Kubernetes Ingress path type.

Build:
- Increase MongoDB memory limits and requests from 256Mi to 512Mi in Helm values.
- Update Ingress manifest to use the correct capitalized Kubernetes pathType value for the DRS filer service.